### PR TITLE
Fix: Cannot read property 'type' of undefined

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -62,7 +62,7 @@ class BootstrapTable extends Component {
       const nextDataFields = React.Children.map(props.children, column => column.props.dataField);
       React.Children.forEach(this.props.children, column => {
         const { dataField, filter } = column.props;
-        if (!nextDataFields.includes(dataField)) {
+        if (filter && !nextDataFields.includes(dataField)) {
           // Clear filter
           this.filter.handleFilter(dataField, '', filter.type, filter);
         }


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'type' of undefined
    at BootstrapTable.js:228
    at forEachSingleChild (ReactChildren.js:49)
    at traverseAllChildrenImpl (traverseAllChildren.js:75)
    at traverseAllChildrenImpl (traverseAllChildren.js:91)
    at traverseAllChildren (traverseAllChildren.js:170)
    at Object.forEachChildren [as forEach] (ReactChildren.js:69)
    at BootstrapTable.initTable (BootstrapTable.js:221)
    at BootstrapTable.initTable (createPrototypeProxy.js:44)
    at BootstrapTable.componentWillReceiveProps (BootstrapTable.js:419)
    at BootstrapTable.componentWillReceiveProps (createPrototypeProxy.js:44)